### PR TITLE
Add IOKitPersonalities dict for the data interface

### DIFF
--- a/HoRNDIS-Info.plist
+++ b/HoRNDIS-Info.plist
@@ -26,6 +26,21 @@
 	<string>6</string>
 	<key>IOKitPersonalities</key>
 	<dict>
+		<key>HoRNDISData</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.joshuawise.kexts.HoRNDIS</string>
+			<key>IOClass</key>
+			<string>HoRNDISUSBInterface</string>
+			<key>IOProviderClass</key>
+			<string>IOUSBInterface</string>
+			<key>bInterfaceClass</key>
+			<integer>10</integer>
+			<key>bInterfaceProtocol</key>
+			<integer>0</integer>
+			<key>bInterfaceSubClass</key>
+			<integer>0</integer>
+		</dict>
 		<key>HoRNDISComposite_SGS2</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This seems to fix basic operation on El Capitan. There are still issues with unplugging and replugging a device, though.