### PR TITLE
Adds installation instructions for Homebrew users

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ For more information, [visit the home page for HoRNDIS on my site](http://www.jo
 
 ### Installation
 
-* Get the installation package (Download[^download_footer] or [Build](#building-the-source) the installation package from source yourself)
+* Get the installation package ([Download](http://www.joshuawise.com/horndis) or [Build](#building-the-source) the installation package from source yourself)
 * Run the installation package
 * Assuming that the installation proceeds without errors, after it completes, connect your phone to your Mac by USB.
 * Enter the settings menu on your phone.
-* In the connections section, below Wi-Fi and Bluetooth, select “More...”.
-Select “Tethering & portable hotspot”.
-* Check the “USB tethering” box. It should flash once, and then become solidly checked.
+* In the connections section, below Wi-Fi and Bluetooth:
+  * Select "More..."
+  * Select "Tethering & portable hotspot"
+* Check the "USB tethering" box. It should flash once, and then become solidly checked.
 
 ### Uninstallation
 
@@ -24,5 +25,3 @@ Select “Tethering & portable hotspot”.
 * `git clone` the repository
 * Simply running xcodebuild in the checkout directory should be sufficient to build the kext.
 * If you wish to package it up, you can run `make` to assemble the package in the build/ directory
-
-[^download_footer]: To download the installation package, please [visit](http://www.joshuawise.com/horndis)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,22 @@
 
 For more information, [visit the home page for HoRNDIS on my site](http://www.joshuawise.com/horndis).
 
-### Installation
+## Installation
+
+### From Source/Binary
 
 * Get the installation package ([Download](http://www.joshuawise.com/horndis) or [Build](#building-the-source) the installation package from source yourself)
 * Run the installation package
+
+### From Homebrew
+
+```sh
+brew cask install horndis
+sudo kextload /Library/Extensions/HoRNDIS.kext
+```
+
+## Configuration
+
 * Assuming that the installation proceeds without errors, after it completes, connect your phone to your Mac by USB.
 * Enter the settings menu on your phone.
 * In the connections section, below Wi-Fi and Bluetooth:
@@ -15,12 +27,12 @@ For more information, [visit the home page for HoRNDIS on my site](http://www.jo
   * Select "Tethering & portable hotspot"
 * Check the "USB tethering" box. It should flash once, and then become solidly checked.
 
-### Uninstallation
+## Uninstallation
 
 * Delete the `HoRNDIS.kext` under `/System/Library/Extensions` and `/Library/Extensions` folder
 * Restart your computer
 
-### Building the source
+## Building the source
 
 * `git clone` the repository
 * Simply running xcodebuild in the checkout directory should be sufficient to build the kext.


### PR DESCRIPTION
This PR addressed the following:

* Adds installation instructions for Homebrew users. This ensures that commonly-referred-to instructions from #59 are officially documented, saving users time having to Google for this instead
* Separates out the installation instructions from the configuration instructions
* Other general Markdown fixes

I hope this helps. Thank you.