### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For more information, [visit the home page for HoRNDIS on my site](http://www.jo
 ### From Homebrew
 
 ```sh
-brew cask install horndis
+brew install --cask horndis
 sudo kextload /Library/Extensions/HoRNDIS.kext
 ```
 


### PR DESCRIPTION
Newer versions of Homebrew require using `--cask` as a flag instead of as a command section, therefore the change in the install instructions under [`README`](/jwise/HoRNDIS/blob/master/README.md).

Here's a screenshot with an example of what I just mentioned.

[![asciicast](https://asciinema.org/a/uJN6PotrkeNLnUQqDNrdRaFKQ.svg?t=38)](https://asciinema.org/a/uJN6PotrkeNLnUQqDNrdRaFKQ?t=33:38)